### PR TITLE
Travis CI: OpenJDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+  - openjdk11
 script:
   - mvn clean install
 after_success:

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <version.jacoco-maven-plugin>0.7.4.201502262128</version.jacoco-maven-plugin>
+    <version.jacoco-maven-plugin>0.8.2</version.jacoco-maven-plugin>
   </properties>
 
   <parent>


### PR DESCRIPTION
PR adds `openjdk11` to Travis CI build matrix